### PR TITLE
Add generator.js to package.json "files".

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "files": [
     "index.js",
+    "generator.js",
     "LICENSE",
     "templates"
   ],


### PR DESCRIPTION
I'm getting this error on a fresh install of `generate` and `generate-generator`:

```
module.js:442
    throw err;
    ^

Error: Cannot find module './generator'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/jamen/.nvm/versions/node/v6.2.2/lib/node_modules/generate-generator/index.js:1:80)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
```

I think this is a fix
